### PR TITLE
Remove ambient from registry search

### DIFF
--- a/src/api/routes/support/db.ts
+++ b/src/api/routes/support/db.ts
@@ -3,7 +3,6 @@ import Promise = require('any-promise')
 import db from '../../../support/knex'
 import arrify = require('arrify')
 import createError = require('http-errors')
-import { AMBIENT_SOURCES, MAIN_SOURCES, ALL_SOURCES } from '../../../support/constants'
 
 export function getEntry (source: string, name: string) {
   return db('entries')
@@ -103,7 +102,6 @@ export interface SearchOptions {
   limit?: number
   sort?: string
   order?: string
-  ambient?: string
   source?: string
 }
 
@@ -124,20 +122,14 @@ export function search (options: SearchOptions) {
     dbQuery.andWhere('entries.name', options.name)
   }
 
-  let sources = ALL_SOURCES
-
-  // Override the sources search using `source=` or `ambient=`.
+  // Override the sources search using `source=`.
   if (options.source) {
-    sources = arrify(options.source)
-  } else if (options.ambient) {
-    sources = options.ambient === 'true' ? AMBIENT_SOURCES : MAIN_SOURCES
+    dbQuery.where(function () {
+      for (const source of arrify(options.source)) {
+        this.orWhere('entries.source', source)
+      }
+    })
   }
-
-  dbQuery.where(function () {
-    for (const source of sources) {
-      this.orWhere('entries.source', source)
-    }
-  })
 
   const totalQuery = dbQuery
     .clone()

--- a/src/support/constants.ts
+++ b/src/support/constants.ts
@@ -12,11 +12,6 @@ export const JOB_INDEX_TYPINGS_COMMIT = 'INDEX_TYPINGS_COMMIT'
 export const JOB_INDEX_DT_FILE_CHANGE = 'INDEX_DT_FILE_CHANGE'
 export const JOB_INDEX_TYPINGS_FILE_CHANGE = 'INDEX_TYPINGS_FILE_CHANGE'
 
-/* Sources */
-export const AMBIENT_SOURCES = ['dt', 'env', 'lib', 'global']
-export const MAIN_SOURCES = ['npm', 'bower', 'github', 'common', 'shared']
-export const ALL_SOURCES = MAIN_SOURCES.concat(AMBIENT_SOURCES)
-
 /* Repos */
 export const REPO_DT_PATH = join(DATA_PATH, 'DefinitelyTyped')
 export const REPO_DT_URL = 'https://github.com/DefinitelyTyped/DefinitelyTyped.git'


### PR DESCRIPTION
Can't really be merged until Typings 0.6 goes out of fashion as the old install steps used "ambient" search.