### PR TITLE
Change the value of `limit` from 50 to 100

### DIFF
--- a/src/api/routes/support/db.ts
+++ b/src/api/routes/support/db.ts
@@ -127,7 +127,7 @@ export interface SearchOptions {
 
 export function search (options: SearchOptions) {
   const offset = Math.max(+options.offset || 0, 0)
-  const limit = Math.max(Math.min(+options.limit || 20, 50), 1)
+  const limit = Math.max(Math.min(+options.limit || 20, 100), 1)
   const sort = options.sort || 'name'
   const order = options.order === 'desc' ? 'desc' : 'asc'
 


### PR DESCRIPTION
Hello :)

`typings` defines the following.
`Limit to "x" results (default: 20, max: 100)`

I changed the max limit.

```
 ᐅ typings search --limit 90
Viewing 50 of 2040

...
```

url: `https://api.typings.org/search?limit=100`

`results` has 50 items.

thanks.