### PR TITLE
Switch from h3 to h4 in README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -36,7 +36,7 @@ Simple RESTful API for typings integration. Available at https://api.typings.org
 
 > Get the latest version matching the semver range.
 
-### /tags/:tag
+#### /tags/:tag
 
 > Select a particular tag from the registry.
 


### PR DESCRIPTION
path 
`http://localhost:5000/entries/dt/xxxx/tags/xxxxxx`

 I switch from `h3` to `h4` because `/tags/:tag` is contained by `/entries/:source/:name`.

thanks:)